### PR TITLE
module files placed in install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,9 @@ set ( mom6_da_hooks_files
     src/core/write_ocean_obs.F90
 )
 
+if(ECBUILD_INSTALL_FORTRAN_MODULES)
+  install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR} DESTINATION ${INSTALL_INCLUDE_DIR})
+endif()
 ################################################################################
 # Library
 ################################################################################


### PR DESCRIPTION
fortran module files were not placed correctly when doing a `make install`